### PR TITLE
Change to use HTTPS

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/vojtajina/node-di.git"
+    "url": "https://github.com/vojtajina/node-di.git"
   },
   "keywords": [
     "di",


### PR DESCRIPTION
Many places block the "git" port.  Using the much more popular "https" port will work better for coffee shops, hotels and enterprise networks.

I found that this is blocked for me when trying to install Karma.  It would be nice if you can get this change in and publish 0.0.2 to npm's list.  Then I can start using Karma 0.10.0 without getting download errors.
