### PR TITLE
Support asynchronous invoke()'d functions

### DIFF
--- a/lib/injector.js
+++ b/lib/injector.js
@@ -62,9 +62,25 @@ var Injector = function(modules, parent) {
     return typeof returned === 'object' ? returned : instance;
   };
 
-  var invoke = function(fn, context) {
+  var invoke = function(fn, context, done) {
     if (typeof fn !== 'function') {
       throw error('Can not invoke "' + fn + '". Expected a function!');
+    }
+
+    var async = false;
+
+    if (typeof done === 'function') {
+      if (!context) {
+        context = {};
+      }
+      context.async = function() {
+        async = true;
+        return function(result) {
+          setTimeout(function() {
+            done(result);
+          });
+        };
+      };
     }
 
     var inject = fn.$inject && fn.$inject || autoAnnotate(fn);
@@ -73,7 +89,14 @@ var Injector = function(modules, parent) {
     });
 
     // TODO(vojta): optimize without apply
-    return fn.apply(context, dependencies);
+    var result = fn.apply(context, dependencies);
+
+    if (!async) {
+      if (typeof done === 'function') {
+        done(result);
+      }
+      return result;
+    }
   };
 
 

--- a/test/injector.spec.coffee
+++ b/test/injector.spec.coffee
@@ -183,6 +183,26 @@ describe 'injector', ->
       expect(injector.invoke bar).to.deep.equal {baz: 'baz-value', abc: 'abc-value'}
 
 
+    it 'should support invokation of asynchronous modules', (finished) ->
+      @timeout 500
+
+      bar = `function(baz, abc) {
+        var done = this.async();
+        done({baz: baz, abc: abc});
+      }`
+
+      module = new Module
+      module.value 'baz', 'baz-value'
+      module.value 'abc', 'abc-value'
+
+      injector = new Injector [module]
+
+      done = (result) ->
+        expect(result).to.deep.equal {baz: 'baz-value', abc: 'abc-value'}
+        do finished
+
+      injector.invoke bar, null, done
+
   describe 'instantiate', ->
 
     it 'should resolve dependencies', ->


### PR DESCRIPTION
Similar to ngRoute's `resolve` property in route configuration, it should be possible to support asynchronous module dependencies in this fashion.

I opened https://github.com/karma-runner/karma/issues/851 on karma a while ago, but it seems like the simplest solution would be adjusting the DI mechanics.

I'll work on a patch for this, but it would be good to hear thoughts about it.

... hmmm I guess it's not easy to do this without changing the API :(

Would it be okay for `invoke()` to return a promise, so that it could wait for promises to be resolved? (realizing fully well that this would be a pretty breaking change)

...

Alternatively, a similar approach to grunt --- call a module with a context containing a method like `async()` which would return a means to notify the caller that it was finished... and just block until everything is finished... although that might not necessarily work either. hmmm :(
