### PR TITLE
Short syntax

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,13 @@
 module.exports = {
   annotate: require('./annotation').annotate,
   Module: require('./module'),
-  Injector: require('./injector')
+  Injector: require('./injector'),
+  factory  : function (fn) {
+    fn.$type = 'factory';
+    return fn;
+  },
+  type : function (fn) {
+    fn.$type = 'type';
+    return fn;
+  }
 };

--- a/lib/injector.js
+++ b/lib/injector.js
@@ -67,7 +67,7 @@ var Injector = function(modules, parent) {
       throw error('Can not invoke "' + fn + '". Expected a function!');
     }
 
-    var inject = fn.$inject && fn.$inject || autoAnnotate(fn);
+    var inject = fn.$inject || autoAnnotate(fn);
     var dependencies = inject.map(function(dep) {
       return get(dep);
     });
@@ -96,6 +96,12 @@ var Injector = function(modules, parent) {
       var cacheIdx;
       var privateChildInjector;
       var privateChildInjectorFactory;
+      var processProvider = function(provider) {
+        if (typeof provider[1] == 'function') {
+          provider[1].$type = provider[2];
+        }
+        return provider[1];
+      };
       for (var name in providers) {
         provider = providers[name];
 
@@ -113,7 +119,7 @@ var Injector = function(modules, parent) {
               fromParentModule[name] = [privateChildFactories[cacheIdx], name, 'private', privateChildInjectors[cacheIdx]];
             }
           } else {
-            fromParentModule[name] = [provider[2], provider[1]];
+            fromParentModule[name] = processProvider(provider);
           }
           matchedScopes[name] = true;
         }
@@ -121,7 +127,7 @@ var Injector = function(modules, parent) {
         if ((provider[2] === 'factory' || provider[2] === 'type') && provider[1].$scope) {
           forceNewInstances.forEach(function(scope) {
             if (provider[1].$scope.indexOf(scope) !== -1) {
-              fromParentModule[name] = [provider[2], provider[1]];
+              fromParentModule[name] = processProvider(provider);
               matchedScopes[scope] = true;
             }
           });
@@ -176,13 +182,14 @@ var Injector = function(modules, parent) {
         });
       } else {
         Object.keys(module).forEach(function(name) {
-          if (module[name][2] === 'private') {
-            providers[name] = module[name];
+          var m = module[name];
+          if (Array.isArray(m) && m[2] === 'private') {
+            providers[name] = m;
             return;
           }
 
-          var type = module[name][0];
-          var value = module[name][1];
+          var value = m;
+          var type = m.$type || 'value';
 
           providers[name] = [factoryMap[type], value, type];
         });

--- a/lib/injector.js
+++ b/lib/injector.js
@@ -79,7 +79,7 @@ var Injector = function(modules, parent) {
 
   var createPrivateInjectorFactory = function(privateChildInjector) {
     return annotate(function(key) {
-      return privateChildInjector.get(key)
+      return privateChildInjector.get(key);
     });
   };
 
@@ -169,7 +169,7 @@ var Injector = function(modules, parent) {
 
         var privateInjector = new Injector((module.__modules__ || []).concat([clonedModule]), self);
         var getFromPrivateInjector = annotate(function(key) {
-          return privateInjector.get(key)
+          return privateInjector.get(key);
         });
         module.__exports__.forEach(function(key) {
           providers[key] = [getFromPrivateInjector, key, 'private', privateInjector];


### PR DESCRIPTION
instead of writing

```
var module = {
  car: ['type', Car],
  power: ['value', 1184]
}
```

you simply write

```
var module = {
  car: di.type(Car),
  power: 1184
}
```
